### PR TITLE
feat: added support for passing multiple parachains in -p flag

### DIFF
--- a/cli/cmd/chains/kusama/cmd.go
+++ b/cli/cmd/chains/kusama/cmd.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	configFilePath string
-	paraChain      string
+	paraChain      []string
 	network        string
 	noRelay        bool
 	explorer       bool
@@ -34,7 +34,7 @@ var KusamaCmd = common.NewDiveCommandBuilder().
 	SetShort("Build, initialize and start a Kusama node").
 	SetLong("The command starts the kusama relay chain and kusama parachain if -p flag is given").
 	SetRun(kusama).
-	AddStringFlagWithShortHand(&paraChain, "parachain", "p", "", "specify the parachain to spawn parachain node").
+	AddStringSliceFlagWithShortHand(&paraChain, "parachain", "p", []string{}, "specify the parachain to spawn parachain node").
 	AddStringFlagWithShortHand(&network, "network", "n", "", "specify the network to run (local/testnet/mainnet). Default will be local.").
 	AddBoolFlag(&noRelay, "no-relay", false, "specify the bool flag to run parachain only (only for testnet and mainnet)").
 	AddStringFlagWithShortHand(&configFilePath, "config", "c", "", "path to custom config json file to start kusama relaychain and parachain nodes.").

--- a/cli/cmd/chains/kusama/cmd.go
+++ b/cli/cmd/chains/kusama/cmd.go
@@ -34,7 +34,7 @@ var KusamaCmd = common.NewDiveCommandBuilder().
 	SetShort("Build, initialize and start a Kusama node").
 	SetLong("The command starts the kusama relay chain and kusama parachain if -p flag is given").
 	SetRun(kusama).
-	AddStringSliceFlagWithShortHand(&paraChain, "parachain", "p", []string{}, "specify the parachain to spawn parachain node").
+	AddStringSliceFlagWithShortHand(&paraChain, "parachain", "p", []string{}, "specify the list of parachains to spawn parachain node").
 	AddStringFlagWithShortHand(&network, "network", "n", "", "specify the network to run (local/testnet/mainnet). Default will be local.").
 	AddBoolFlag(&noRelay, "no-relay", false, "specify the bool flag to run parachain only (only for testnet and mainnet)").
 	AddStringFlagWithShortHand(&configFilePath, "config", "c", "", "path to custom config json file to start kusama relaychain and parachain nodes.").

--- a/cli/cmd/chains/kusama/run.go
+++ b/cli/cmd/chains/kusama/run.go
@@ -53,7 +53,8 @@ func RunKusama(cli *common.Cli) (*common.DiveMultipleServiceResponse, error) {
 	}
 
 	result := &common.DiveMultipleServiceResponse{}
-	if noRelay {
+
+	if serviceConfig.RelayChain.Name == "" {
 		result, err = startParaChains(cli, enclaveContext, serviceConfig, encodedServiceConfigDataString, "")
 		if err != nil {
 			return nil, err
@@ -255,6 +256,10 @@ func configureService(serviceConfig *utils.PolkadotServiceConfig) error {
 		return common.WrapMessageToError(common.ErrInvalidFlag, "The '--no-relay' flag cannot be used with a 'local' network. This flag is only applicable for 'testnet' and 'mainnet' networks.")
 	} else if noRelay && serviceConfig.ChainType != "local" {
 		serviceConfig.RelayChain = utils.RelayChainConfig{}
+	}
+
+	if serviceConfig.ChainType == localChain && serviceConfig.RelayChain.Name == "" && len(serviceConfig.Para) != 0 {
+		return common.WrapMessageToError(common.ErrEmptyFields, "Cannot start a Parachain in local without Relay Chain")
 	}
 
 	return nil

--- a/cli/cmd/chains/polkadot/cmd.go
+++ b/cli/cmd/chains/polkadot/cmd.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	configFilePath string
-	paraChain      string
+	paraChain      []string
 	network        string
 	noRelay        bool
 	explorer       bool
@@ -21,7 +21,7 @@ const (
 	runPolkadotFunctionName             = "run_polkadot_setup"
 	runPolkadotRelayLocal               = "start_relay_chains_local"
 	runPolkadotRelayTestnetMainet       = "start_test_main_net_relay_nodes"
-	runUploadFiles                    = "upload_files"
+	runUploadFiles                      = "upload_files"
 	runPolkadotParaLocalFunctionName    = "start_nodes"
 	runPolkadotParaTestMainFunctionName = "run_testnet_mainnet"
 	runPolkadotExplorer                 = "run_pokadot_js_app"
@@ -34,7 +34,7 @@ var PolkadotCmd = common.NewDiveCommandBuilder().
 	SetShort("Build, initialize and start a Polkadot node").
 	SetLong("The command starts the polkadot relay chain and polkadot parachain if -p flag is given").
 	SetRun(polkadot).
-	AddStringFlagWithShortHand(&paraChain, "parachain", "p", "", "specify the parachain to spawn parachain node").
+	AddStringSliceFlagWithShortHand(&paraChain, "parachain", "p", []string{}, "specify the parachain to spawn parachain node").
 	AddStringFlagWithShortHand(&network, "network", "n", "", "specify the network to run (local/testnet/mainnet). Default will be local.").
 	AddBoolFlag(&noRelay, "no-relay", false, "specify the bool flag to run parachain only (only for testnet and mainnet)").
 	AddStringFlagWithShortHand(&configFilePath, "config", "c", "", "path to custom config json file to start polkadot relaychain and parachain nodes.").
@@ -49,8 +49,7 @@ func polkadot(cmd *cobra.Command, args []string) {
 	if err != nil {
 		cliContext.Fatalf("Error %s. %s", err, cmd.UsageString())
 	}
-
-	cliContext.Spinner().StartWithMessage("Starting Polkadot Node", "green")
+	cliContext.StartSpinnerIfNotVerbose("Starting Polkadot Node", common.DiveLogs)
 
 	response, err := RunPolkadot(cliContext)
 	if err != nil {
@@ -76,5 +75,5 @@ func polkadot(cmd *cobra.Command, args []string) {
 		}
 	}
 	stopMessage := fmt.Sprintf("Polkadot Node Started. Please find service details in current working directory(%s)\n", serviceFileName)
-	cliContext.Spinner().StopWithMessage(stopMessage)
+	cliContext.StopSpinnerIfNotVerbose(stopMessage, common.DiveLogs)
 }

--- a/cli/cmd/chains/polkadot/cmd.go
+++ b/cli/cmd/chains/polkadot/cmd.go
@@ -34,7 +34,7 @@ var PolkadotCmd = common.NewDiveCommandBuilder().
 	SetShort("Build, initialize and start a Polkadot node").
 	SetLong("The command starts the polkadot relay chain and polkadot parachain if -p flag is given").
 	SetRun(polkadot).
-	AddStringSliceFlagWithShortHand(&paraChain, "parachain", "p", []string{}, "specify the parachain to spawn parachain node").
+	AddStringSliceFlagWithShortHand(&paraChain, "parachain", "p", []string{}, "specify the list of parachains to spawn parachain node").
 	AddStringFlagWithShortHand(&network, "network", "n", "", "specify the network to run (local/testnet/mainnet). Default will be local.").
 	AddBoolFlag(&noRelay, "no-relay", false, "specify the bool flag to run parachain only (only for testnet and mainnet)").
 	AddStringFlagWithShortHand(&configFilePath, "config", "c", "", "path to custom config json file to start polkadot relaychain and parachain nodes.").

--- a/cli/cmd/chains/polkadot/run.go
+++ b/cli/cmd/chains/polkadot/run.go
@@ -53,7 +53,8 @@ func RunPolkadot(cli *common.Cli) (*common.DiveMultipleServiceResponse, error) {
 	}
 
 	result := &common.DiveMultipleServiceResponse{}
-	if noRelay {
+
+	if serviceConfig.RelayChain.Name == "" {
 		result, err = startParaChains(cli, enclaveContext, serviceConfig, encodedServiceConfigDataString, "")
 		if err != nil {
 			return nil, err
@@ -257,6 +258,10 @@ func configureService(serviceConfig *utils.PolkadotServiceConfig) error {
 		return common.WrapMessageToError(common.ErrInvalidFlag, "The '--no-relay' flag cannot be used with a 'local' network. This flag is only applicable for 'testnet' and 'mainnet' networks.")
 	} else if noRelay && serviceConfig.ChainType != "local" {
 		serviceConfig.RelayChain = utils.RelayChainConfig{}
+	}
+
+	if serviceConfig.ChainType == localChain && serviceConfig.RelayChain.Name == "" && len(serviceConfig.Para) != 0 {
+		return common.WrapMessageToError(common.ErrEmptyFields, "Cannot start a Parachain in local without Relay Chain")
 	}
 
 	return nil

--- a/cli/cmd/chains/polkadot/run.go
+++ b/cli/cmd/chains/polkadot/run.go
@@ -52,9 +52,17 @@ func RunPolkadot(cli *common.Cli) (*common.DiveMultipleServiceResponse, error) {
 		return nil, common.WrapMessageToError(err, "Failed to upload the configuration files.")
 	}
 
-	result, err := startRelayAndParaChain(cli, enclaveContext, serviceConfig, encodedServiceConfigDataString)
-	if err != nil {
-		return nil, err
+	result := &common.DiveMultipleServiceResponse{}
+	if noRelay {
+		result, err = startParaChains(cli, enclaveContext, serviceConfig, encodedServiceConfigDataString, "")
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		result, err = startRelayAndParaChain(cli, enclaveContext, serviceConfig, encodedServiceConfigDataString)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return result, nil
@@ -149,6 +157,8 @@ func startRelayAndParaChain(cli *common.Cli, enclaveContext *enclaves.EnclaveCon
 
 func startParaChains(cli *common.Cli, enclaveContext *enclaves.EnclaveContext, serviceConfig *utils.PolkadotServiceConfig, para string, ipAddress string) (*common.DiveMultipleServiceResponse, error) {
 	paraResult := &common.DiveMultipleServiceResponse{}
+	allParaResult := &common.DiveMultipleServiceResponse{}
+
 	var err error
 
 	if serviceConfig.ChainType == localChain {
@@ -157,6 +167,8 @@ func startParaChains(cli *common.Cli, enclaveContext *enclaves.EnclaveContext, s
 		if err != nil {
 			return nil, err
 		}
+		allParaResult = concatenateDiveResults(allParaResult, paraResult)
+
 	} else {
 		for _, paraNode := range serviceConfig.Para {
 			paraChainConfig, err := paraNode.EncodeToString()
@@ -168,11 +180,11 @@ func startParaChains(cli *common.Cli, enclaveContext *enclaves.EnclaveContext, s
 			if err != nil {
 				return nil, err
 			}
+			allParaResult = concatenateDiveResults(allParaResult, paraResult)
 		}
-
 	}
 
-	return paraResult, nil
+	return allParaResult, nil
 }
 
 func runParaChain(cli *common.Cli, enclaveContext *enclaves.EnclaveContext, serviceConfig *utils.PolkadotServiceConfig, para string) (*common.DiveMultipleServiceResponse, error) {
@@ -212,14 +224,18 @@ func runParaChain(cli *common.Cli, enclaveContext *enclaves.EnclaveContext, serv
 
 func configureService(serviceConfig *utils.PolkadotServiceConfig) error {
 
-	if paraChain != "" {
+	if len(paraChain) != 0 {
 		serviceConfig.Para = []utils.ParaNodeConfig{}
-		serviceConfig.Para = append(serviceConfig.Para, utils.ParaNodeConfig{
-			Name: paraChain,
-			Nodes: []utils.NodeConfig{
-				{Name: "alice", NodeType: "full", Prometheus: false},
-			},
-		})
+		for _, value := range paraChain {
+			if value != "" {
+				serviceConfig.Para = append(serviceConfig.Para, utils.ParaNodeConfig{
+					Name: value,
+					Nodes: []utils.NodeConfig{
+						{Name: "alice", NodeType: "full", Prometheus: false},
+					},
+				})
+			}
+		}
 	}
 
 	if network != "" {
@@ -238,11 +254,9 @@ func configureService(serviceConfig *utils.PolkadotServiceConfig) error {
 	}
 
 	if noRelay && serviceConfig.ChainType == "local" {
-		if serviceConfig.ChainType == "local" {
-			return common.WrapMessageToError(common.ErrInvalidFlag, "The '--no-relay' flag cannot be used with a 'local' network. This flag is only applicable for 'testnet' and 'mainnet' networks.")
-		} else {
-			serviceConfig.RelayChain = utils.RelayChainConfig{}
-		}
+		return common.WrapMessageToError(common.ErrInvalidFlag, "The '--no-relay' flag cannot be used with a 'local' network. This flag is only applicable for 'testnet' and 'mainnet' networks.")
+	} else if noRelay && serviceConfig.ChainType != "local" {
+		serviceConfig.RelayChain = utils.RelayChainConfig{}
 	}
 
 	return nil
@@ -279,13 +293,13 @@ func configureMetrics(serviceConfig *utils.PolkadotServiceConfig) {
 func flagCheck() error {
 
 	if configFilePath != "" {
-		if paraChain != "" || network != "" || explorer || metrics {
+		if len(paraChain) != 0 || network != "" || explorer || metrics {
 			return common.WrapMessageToError(common.ErrInvalidFlag, "The '-c' flag does not allow additional flags.")
 		}
 	}
 
 	if noRelay && (network == "testnet" || network == "mainnet") {
-		if paraChain == "" {
+		if len(paraChain) == 0 {
 			return common.WrapMessageToError(common.ErrMissingFlags, "The '-p' flag is required when using '--no-relay' flag. Please provide the '-p' flag with the parachain name.")
 		}
 	}
@@ -322,7 +336,7 @@ func getIPAddress(cli *common.Cli, serviceConfig *utils.PolkadotServiceConfig, r
 
 			shortUuid, err := cli.Context().GetShortUuid(common.EnclaveName)
 			if err != nil {
-				return "", fmt.Errorf("Failed to retrieve the UUID of the enclave.")
+				return "", fmt.Errorf("failed to retrieve the UUID of the enclave")
 			}
 			serviceFileName := fmt.Sprintf(common.ServiceFilePath, common.EnclaveName, shortUuid)
 
@@ -334,7 +348,7 @@ func getIPAddress(cli *common.Cli, serviceConfig *utils.PolkadotServiceConfig, r
 			chainServiceName := fmt.Sprintf("rococo-local-%s", nodename)
 			chainServiceResponse, OK := services[chainServiceName]
 			if !OK {
-				return "", fmt.Errorf("Service name '%s' not found", chainServiceName)
+				return "", fmt.Errorf("service name '%s' not found", chainServiceName)
 			}
 
 			ipAddress := chainServiceResponse.IpAddress

--- a/cli/cmd/chains/utils/types.go
+++ b/cli/cmd/chains/utils/types.go
@@ -232,17 +232,17 @@ func (psc *PolkadotServiceConfig) IsEmpty() error {
 		return common.WrapMessageToError(common.ErrEmptyFields, "Missing Fields In PolkadotServiceConfig")
 	}
 
-	if psc.Explorer != true && psc.Explorer != false {
-		return common.WrapMessageToError(common.ErrEmptyFields, "Missing Fields In PolkadotServiceConfig")
-	}
-
 	if err := psc.RelayChain.IsEmpty(); err != nil {
 		return err
 	}
 
-	for _, para := range psc.Para {
-		if err := para.IsEmpty(); err != nil {
-			return err
+	if len(psc.Para) == 0 {
+		return nil
+	} else {
+		for _, para := range psc.Para {
+			if err := para.IsEmpty(); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -251,7 +251,11 @@ func (psc *PolkadotServiceConfig) IsEmpty() error {
 
 func (rcc *RelayChainConfig) IsEmpty() error {
 
-	if rcc == nil || rcc.Name == "" || len(rcc.Nodes) == 0 {
+	if rcc.Name == "" && len(rcc.Nodes) == 0 {
+		return nil
+	}
+
+	if rcc.Name == "" || len(rcc.Nodes) == 0 {
 		return common.WrapMessageToError(common.ErrEmptyFields, "Missing Fields In RelayChainConfig")
 	}
 
@@ -283,10 +287,6 @@ func (nc *NodeConfig) IsEmpty() error {
 
 	if nc == nil || nc.Name == "" || nc.NodeType == "" {
 		return common.WrapMessageToError(common.ErrEmptyFields, "Missing Fields In NodeConfig")
-	}
-
-	if nc.Prometheus != true && nc.Prometheus != false {
-		return common.WrapMessageToError(common.ErrEmptyFields, "Missing Fields In PolkadotServiceConfig")
 	}
 
 	return nil

--- a/cli/common/command_builder.go
+++ b/cli/common/command_builder.go
@@ -55,6 +55,12 @@ func (dc *diveCommandBuilder) AddStringFlagWithShortHand(stringV *string, name s
 	return dc
 }
 
+// Add StringSliceFlag adds a slice of string flag to the command that persists with short hand
+func (dc *diveCommandBuilder) AddStringSliceFlagWithShortHand(stringV *[]string, name string, shorthand string, value []string, usage string) CommandBuilder {
+	dc.cmd.Flags().StringSliceVarP(stringV, name, shorthand, value, usage)
+	return dc
+}
+
 // Add BooFlag adds a boolean flag to the command that persists
 func (dc *diveCommandBuilder) AddBoolFlag(boolV *bool, name string, value bool, usage string) CommandBuilder {
 	dc.cmd.Flags().BoolVar(boolV, name, value, usage)

--- a/cli/common/interfaces.go
+++ b/cli/common/interfaces.go
@@ -197,6 +197,9 @@ type CommandBuilder interface {
 	// Add StringFlag adds a string flag to the command that persists with short hand
 	AddStringFlagWithShortHand(stringV *string, name string, shorthand string, value string, usage string) CommandBuilder
 
+	// Add StringSliceFlag adds a slice of string flag to the command that persists with short hand
+	AddStringSliceFlagWithShortHand(stringV *[]string, name string, shorthand string, value []string, usage string) CommandBuilder
+
 	// Add BooFlag adds a boolean flag to the command that persists
 	AddBoolFlag(boolV *bool, name string, value bool, usage string) CommandBuilder
 


### PR DESCRIPTION
## Description:
Added support to pass multiple parachains to the -p flag.
Added verbose for polkadot

### Commit Message

```bash
feat: added support for passing multiple parachains in -p flag
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
