### PR TITLE
feat: implement automate opening of polkadot explorer UI when explorer flag is given

### DIFF
--- a/cli/cmd/chains/kusama/run.go
+++ b/cli/cmd/chains/kusama/run.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	localChain = "local"
+	polkadotJUrl = "http://127.0.0.1:80"
 )
 
 func RunKusama(cli *common.Cli) (*common.DiveMultipleServiceResponse, error) {
@@ -164,6 +165,13 @@ func startRelayAndParaChain(cli *common.Cli, enclaveContext *enclaves.EnclaveCon
 			return nil, err
 		}
 		finalResult = finalResult.ConcatenateDiveResults(explorerResult)
+
+		cli.Logger().Info("Redirecting to Polkadot explorer UI...")
+		if err := common.OpenFile(polkadotJUrl); err != nil {
+			cli.Logger().Fatalf(common.CodeOf(err), "Failed to open HugoByte Polkadot explorer UI with error %v", err)
+		}
+		
+		
 	}
 
 	return finalResult, nil

--- a/cli/cmd/chains/polkadot/run.go
+++ b/cli/cmd/chains/polkadot/run.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	localChain = "local"
+	polkadotJUrl = "http://127.0.0.1:80"
 )
 
 func RunPolkadot(cli *common.Cli) (*common.DiveMultipleServiceResponse, error) {
@@ -164,6 +165,11 @@ func startRelayAndParaChain(cli *common.Cli, enclaveContext *enclaves.EnclaveCon
 			return nil, err
 		}
 		finalResult = finalResult.ConcatenateDiveResults(explorerResult)
+
+		cli.Logger().Info("Redirecting to Polkadote explorer UI...")
+		if err := common.OpenFile(polkadotJUrl); err != nil {
+			cli.Logger().Fatalf(common.CodeOf(err), "Failed to open HugoByte Polkadot explorer UI with error %v", err)
+		}
 	}
 
 	return finalResult, nil


### PR DESCRIPTION
…r flag is given

## Description:

### Commit Message

```bash
feat: implement automate opening of polkadot explorer UI when explorer flag is given
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
